### PR TITLE
Fix taxi

### DIFF
--- a/rwengine/include/objects/VehicleObject.hpp
+++ b/rwengine/include/objects/VehicleObject.hpp
@@ -132,6 +132,12 @@ public:
 	void setPrimaryColour(uint8_t color);
 	void setSecondaryColour(uint8_t color);
 
+	/**
+	* @brief isStopped
+	* @return True if the vehicle isn't moving
+	*/
+	bool isStopped() const;
+
 private:
 
 	void registerPart(ModelFrame* mf);

--- a/rwengine/src/objects/CharacterObject.cpp
+++ b/rwengine/src/objects/CharacterObject.cpp
@@ -467,8 +467,11 @@ bool CharacterObject::enterVehicle(VehicleObject* vehicle, size_t seat)
 
 bool CharacterObject::isStopped() const
 {
-	RW_UNIMPLEMENTED("Checking if character is stopped");
-	return true;
+	if (currentVehicle != nullptr) {
+		return currentVehicle->isStopped();
+	}
+
+	return controller->getCurrentActivity() == nullptr;
 }
 
 VehicleObject *CharacterObject::getCurrentVehicle() const

--- a/rwengine/src/objects/VehicleObject.cpp
+++ b/rwengine/src/objects/VehicleObject.cpp
@@ -752,6 +752,11 @@ void VehicleObject::setSecondaryColour(uint8_t color)
 	colourSecondary = engine->data->vehicleColours[color];
 }
 
+bool VehicleObject::isStopped() const
+{
+	return fabsf(physVehicle->getCurrentSpeedKmHour()) < 0.75f;
+}
+
 void *VehicleRaycaster::castRay(const btVector3 &from, const btVector3 &to, btVehicleRaycaster::btVehicleRaycasterResult &result)
 {
 	ClosestNotMeRayResultCallback rayCallback( _vehicle->physBody, from, to );

--- a/rwengine/src/script/modules/GameModule.cpp
+++ b/rwengine/src/script/modules/GameModule.cpp
@@ -1349,7 +1349,8 @@ GameModule::GameModule()
 	bindFunction(0x030D, game_set_max_progress, 1, "Set Max Progress" );
 
 	bindFunction(0x0314, game_set_unique_jumps, 1, "Set Total Unique Jumps" );
-	
+	bindUnimplemented( 0x0315, game_increment_taxi_dropoffs, 0, "Increment Taxi Dropoffs" );
+	bindUnimplemented( 0x0316, game_register_taxi_money, 1, "Register Taxi Money" );
 	bindUnimplemented( 0x0317, game_increment_mission_attempts, 0, "Increment Mission Attempts" );
 	bindFunction(0x0318, game_set_last_mission, 1, "Set Last completed mission" );
 	

--- a/rwengine/src/script/modules/GameModule.cpp
+++ b/rwengine/src/script/modules/GameModule.cpp
@@ -1247,7 +1247,7 @@ GameModule::GameModule()
 
 	bindFunction(0x018A, game_add_location_blip, 4, "Add Blip for Coord");
 	bindFunction(0x018B, game_change_blip_mode, 2, "Change Blip Display Mode");
-	
+	bindUnimplemented( 0x018C, game_play_sound_at, 4, "Play Sound At" );
 	bindUnimplemented( 0x018D, game_create_soundscape, 5, "Create soundscape" );
 
 	bindUnimplemented( 0x018E, game_remove_sound, 1, "Remove Sound" );

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -335,6 +335,31 @@ bool game_player_stopped_near_point_on_foot_3d(const ScriptArguments& args)
 	return false;
 }
 
+bool game_is_player_in_vehicle_near_character(const ScriptArguments& args)
+{
+	auto player = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
+	auto character = static_cast<CharacterObject*>(args.getObject<CharacterObject>(1));
+	glm::vec3 size(args[2].real, args[3].real, args[4].real);
+	bool drawSphere = !!args[5].integerValue();
+
+	auto center = character->getPosition();
+
+	auto vehicle = player->getCurrentVehicle();
+	if(vehicle) {
+		auto distance = center - player->getPosition();
+		distance /= size;
+		if (glm::length(distance) < 1.f) {
+			return true;
+		}
+	}
+
+	if (drawSphere) {
+		args.getWorld()->drawAreaIndicator(AreaIndicatorInfo::Cylinder, center, size); //FIXME!
+	}
+
+	return false;
+}
+
 bool game_character_near_point_in_vehicle(const ScriptArguments& args)
 {
 	auto character = static_cast<CharacterObject*>(args.getObject<CharacterObject>(0));
@@ -1282,6 +1307,8 @@ ObjectModule::ObjectModule()
     bindFunction(0x00F6, game_player_near_point_on_foot_3D, 8, "Is Player near point on foot" );
     bindFunction(0x00F7, game_player_near_point_in_vehicle_3D, 8, "Is Player near point in car" );
 	bindFunction(0x00F9, game_player_stopped_near_point_on_foot_3d, 8, "Detect player stopped on foot area 3d" );
+
+	bindFunction(0x00FD, game_is_player_in_vehicle_near_character, 6, "Is Player in Vehicle Near Character");
 
 	bindFunction(0x0100, game_character_near_point_in_vehicle, 8, "Is Character near point in car" );
 	

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -636,6 +636,14 @@ bool game_vehicle_stopped(const ScriptArguments& args)
 	return false;
 }
 
+bool game_is_vehicle_health_greater_than(const ScriptArguments& args)
+{
+	RW_UNIMPLEMENTED("game_is_vehicle_health_greater_than");
+	RW_UNUSED(args);
+	/// @todo
+	return true;
+}
+
 /// Remove object from cleanup at end of missions.
 void game_dont_remove_object(const ScriptArguments& args)
 {
@@ -1339,6 +1347,8 @@ ObjectModule::ObjectModule()
 	
 	bindFunction(0x0176, game_get_object_heading<InstanceObject>, 2, "Get Object heading" );
 	bindFunction(0x0177, game_set_object_heading<InstanceObject>, 2, "Set Object heading" );
+
+	bindFunction(0x0185, game_is_vehicle_health_greater_than, 2, "Is Vehicle Health Greater Than" );
 	
 	bindUnimplemented( 0x0192, game_character_stand_still, 1, "Make character stand still" );
 	

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -687,21 +687,12 @@ bool game_character_stoped_in_volume(const ScriptArguments& args)
 	
 	glm::vec3 pp = character->getPosition();
 	
-	if( pp.x >= min.x && pp.y >= min.y && pp.z >= min.z &&
-		pp.x <= max.x && pp.y <= max.y && pp.z <= max.z )
-	{
-		if( character->getCurrentVehicle() != nullptr )
-		{
-			return character->getCurrentVehicle()->physVehicle->getCurrentSpeedKmHour() < 0.75f;
-		}
-		else
-		{
-			return character->controller->getCurrentActivity() == nullptr;
-		}
+	if (pp.x >= min.x && pp.y >= min.y && pp.z >= min.z &&
+	    pp.x <= max.x && pp.y <= max.y && pp.z <= max.z) {
+		return character->isStopped();
 	}
 	
-	if( drawCylinder )
-	{
+	if (drawCylinder) {
 		args.getWorld()->drawAreaIndicator(AreaIndicatorInfo::Cylinder, (max+min)/2.f, (max-min)/2.f);
 	}
 	

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -48,11 +48,21 @@ void game_create_player(const ScriptArguments& args)
 }
 
 template<class Tobject>
+void game_get_object_position(const ScriptArguments& args)
+{
+	auto object = args.getObject<Tobject>(0);
+	auto position = object->getPosition();
+	*args[1].globalReal = position.x;
+	*args[2].globalReal = position.y;
+	*args[3].globalReal = position.z;
+}
+
+template<class Tobject>
 void game_set_object_position(const ScriptArguments& args)
 {
-	auto character = args.getObject<Tobject>(0);
+	auto object = args.getObject<Tobject>(0);
 	glm::vec3 position(args[1].real, args[2].real, args[3].real);
-	character->setPosition(position + spawnMagic);
+	object->setPosition(position + spawnMagic);
 }
 
 bool game_player_in_area_2d(const ScriptArguments& args)
@@ -1234,6 +1244,7 @@ ObjectModule::ObjectModule()
 	
 	bindUnimplemented( 0x009F, game_character_make_idle, 1, "Set Character to Idle" );
 	
+	bindFunction(0x00A0, game_get_object_position<CharacterObject>, 4, "Get Character Position" );
 	bindFunction(0x00A1, game_set_object_position<CharacterObject>, 4, "Set Character Position" );
 	
 	bindFunction(0x00A5, game_create_vehicle, 5, "Create Vehicle" );

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -1451,6 +1451,8 @@ ObjectModule::ObjectModule()
 
 	bindUnimplemented( 0x0243, game_set_character_personality, 2, "Set Character Personality" );
 	
+	bindUnimplemented( 0x0291, set_character_attack_when_provoked, 2, "Set Character Attack When Provoked" );
+
 	bindFunction(0x029B, game_create_object_world, 5, "Create Object no offset" );
 	bindFunction(0x029C, game_is_boat, 1, "Is Vehicle Boat" );
 	

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -1197,6 +1197,13 @@ void game_set_close_object_visible(const ScriptArguments& args)
 	}
 }
 
+void game_set_character_running(const ScriptArguments& args)
+{
+	auto character = static_cast<CharacterObject*>(args.getObject<CharacterObject>(0));
+	bool running = !!args[1].integerValue();
+	character->setRunning(running);
+}
+
 void game_change_nearest_model(const ScriptArguments& args)
 {
 	glm::vec3 position(args[0].real, args[1].real, args[2].real);
@@ -1456,6 +1463,7 @@ ObjectModule::ObjectModule()
 	
 	bindFunction(0x02E3, game_get_speed, 2, "Get Vehicle Speed" );
 
+	bindFunction(0x0319, game_set_character_running, 2, "Set Character Running" );
 	bindFunction(0x0320, game_character_in_range, 2, "Is Character in range of character");
 
 	bindFunction(0x032B, game_create_weapon_pickup, 7, "Create Weapon Pickup" );

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -1441,8 +1441,10 @@ ObjectModule::ObjectModule()
 	bindFunction(0x0213, game_create_pickup, 6, "Create pickup");
 	bindFunction(0x0214, game_is_pickup_collected, 1, "Has Pickup been collected");
 	bindFunction(0x0215, game_destroy_pickup, 1, "Destroy Pickup");
+	bindUnimplemented( 0x0216, game_set_taxi_available_light, 2, "Set Taxi Available Light" );
 
 	bindFunction(0x0227, game_get_vehicle_health, 2, "Get Vehicle Health" );
+	
 	bindFunction(0x0229, game_set_vehicle_colours, 3, "Set Vehicle Colours" );
 	
 	bindFunction(0x0239, game_character_run_to, 3, "Character Run to" );

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -764,6 +764,32 @@ bool game_locate_vehicle_near_point_2D(const ScriptArguments& args)
 	return false;
 }
 
+bool game_vehicle_stopped_in_volume(const ScriptArguments& args)
+{
+	auto vehicle = static_cast<VehicleObject*>(args.getObject<VehicleObject>(0));
+	
+	glm::vec3 vec1(args[1].realValue(), args[2].realValue(), args[3].realValue());
+	glm::vec3 vec2(args[4].realValue(), args[5].realValue(), args[6].realValue());
+	bool drawCylinder = !!args[7].integerValue();
+	
+	glm::vec3 min = glm::min(vec1, vec2);
+	glm::vec3 max = glm::max(vec1, vec2);
+	
+	glm::vec3 pp = vehicle->getPosition();
+	
+	if (pp.x >= min.x && pp.y >= min.y && pp.z >= min.z &&
+	    pp.x <= max.x && pp.y <= max.y && pp.z <= max.z) {
+		return vehicle->isStopped();
+	}
+	
+	if (drawCylinder) {
+		args.getWorld()->drawAreaIndicator(AreaIndicatorInfo::Cylinder, (max+min)/2.f, (max-min)/2.f);
+	}
+	
+	return false;
+}
+
+
 template <class T>
 bool game_is_character_stopped(const ScriptArguments& args)
 {
@@ -1404,6 +1430,7 @@ ObjectModule::ObjectModule()
 	bindFunction(0x01A8, game_character_stoped_in_volume<CharacterObject>, 8, "Is Char Stopped in volume" );
 	bindFunction(0x01AA, game_character_stoped_in_volume_in_vehicle<CharacterObject>, 8, "Is Char Stopped in cube in vehicle" );
 
+	bindFunction(0x01AC, game_vehicle_stopped_in_volume, 8, "Is Vehicle Stopped in volume" );
 	bindFunction(0x01AD, game_locate_vehicle_near_point_2D, 6, "Locate Vehicle Near Point 2D" );
 
 	bindFunction(0x01B2, game_give_weapon_to_character, 3, "Give Weapon to Character" );

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -1477,6 +1477,8 @@ ObjectModule::ObjectModule()
 	bindUnimplemented( 0x035D, game_set_object_targetable, 1, "Set Object Targetable" );
 	
 	bindFunction(0x0363, game_set_close_object_visible, 6, "Set Closest Object Visibility");
+
+	bindUnimplemented( 0x0365, game_set_character_objective_to_hail_taxi, 1, "Set Character Objective to Hail Taxi" );
 	
 	bindUnimplemented( 0x0368, game_create_ev_crane, 10, "Create ev Crane" );
 	

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -1433,6 +1433,8 @@ ObjectModule::ObjectModule()
 	bindFunction(0x0204, game_character_near_car_2d, 5, "Is Char near Car in Car 2D" );
 	
 	bindUnimplemented( 0x020A, game_lock_vehicle_doors, 2, "Lock Car Doors" );
+
+	bindUnimplemented( 0x020F, game_turn_character_to_face_player, 2, "Turn Character to Face Player" );
 	
 	bindFunction(0x0211, game_navigate_on_foot, 3, "Character go to on foot" );
 	

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -846,6 +846,42 @@ bool game_player_in_taxi(const ScriptArguments& args)
 	return (vehicle && (vehicle->vehicle->classType & VehicleData::TAXI) == VehicleData::TAXI);
 }
 
+void game_get_random_character_in_zone(const ScriptArguments& args)
+{
+	std::string zname(args[0].string);
+
+	auto zfind = args.getWorld()->data->zones.find(zname);
+	if( zfind != args.getWorld()->data->zones.end() ) {
+
+		auto playerObject = args.getWorld()->pedestrianPool.find(args.getState()->playerObject);
+		auto player = static_cast<CharacterObject*>(playerObject);
+
+		for(auto& p : args.getWorld()->pedestrianPool.objects) {
+
+			auto character = static_cast<CharacterObject*>(p.second);
+
+			RW_UNIMPLEMENTED("Don't grab script chars!");
+			/// @todo don't grab script objects
+			if (character == player) {
+				continue;
+			}
+
+			auto cp = character->getPosition();
+			auto& min = zfind->second.min;
+			auto& max = zfind->second.max;
+			if (cp.x > min.x && cp.y > min.y && cp.z > min.z &&
+			    cp.x < max.x && cp.y < max.y && cp.z < max.z) {
+				*args[1].globalInteger = p.first;
+				return;
+			}
+
+		}
+
+	}
+
+	*args[1].globalInteger = -1;
+}
+
 void game_get_speed(const ScriptArguments& args)
 {
 	auto vehicle = static_cast<VehicleObject*>(args.getObject<VehicleObject>(0));
@@ -1415,6 +1451,7 @@ ObjectModule::ObjectModule()
 
 	bindFunction(0x02BF, game_is_vehicle_in_water, 1, "Is Vehicle in Water" );
 	
+	bindFunction(0x02DD, game_get_random_character_in_zone, 2, "Get Random Character In Zone");
 	bindFunction(0x02DE, game_player_in_taxi, 1, "Is Player In Taxi" );
 	
 	bindFunction(0x02E3, game_get_speed, 2, "Get Vehicle Speed" );

--- a/rwengine/src/script/modules/VMModule.cpp
+++ b/rwengine/src/script/modules/VMModule.cpp
@@ -217,6 +217,18 @@ void vm_mission_over(const ScriptArguments& args)
 	*args.getState()->scriptOnMissionFlag = 0;
 }
 
+void vm_sqrt(const ScriptArguments& args)
+{
+	*args[1].globalReal -= sqrtf(args[0].real);
+}
+
+void vm_random_int_in_range(const ScriptArguments& args)
+{
+  auto min = args[0].integerValue();
+  auto max = args[1].integerValue();
+	*args[2].globalInteger = rand() % (max - min) + min;
+}
+
 void vm_name_thread(const ScriptArguments& args)
 {
 	strncpy(args.getThread()->name, args[0].string, 16);
@@ -299,6 +311,10 @@ VMModule::VMModule()
 	bindFunction(0x0D7, vm_new_mission_thread, 1, "Start Mission Thread");
 
 	bindFunction(0x0D8, vm_mission_over, 0, "Set Mission Finished");
+
+	bindFunction(0x1FB, vm_sqrt, 2, "Sqrt");
+
+	bindFunction(0x209, vm_random_int_in_range, 3, "Random Int in Range");
 
 	bindFunction(0x2CD, vm_call, 2, "Call");
 


### PR DESCRIPTION
This implements (stubs) the 'Taxi Driver' mission.

Known issues (all of which can be fixed after merge):
- Guests often don't want to leave the taxi, teleporting away is a solution (will be fixed after merge once we properly work on AI)
- Peds like to spawn in very bad spots (Unrelated, this is  a problem of the traffic spawner)
- Always claims you earned "$-1" (no idea why)
- Peds don't wait for your taxi and don't hail the taxi (stubbed only)
- Taxi lights stay off (stubbed only)
- Only works on last island (airport etc.) because we currently don't support the script function to check if an island is loaded

---

TODO:
- [x] Split into text rendering and taxi stuff
- [x] Wait for mission vehicle base
- [x] Split into _more_ text rendering
- [x] Split into commits
- [x] Cleanup
- [ ] Testing 
