### PR TITLE
Improve text styles

### DIFF
--- a/rwengine/include/render/TextRenderer.hpp
+++ b/rwengine/include/render/TextRenderer.hpp
@@ -61,7 +61,7 @@ public:
 	
 	void setFontTexture( int index, const std::string& font );
 	
-	void renderText( const TextInfo& ti );
+	void renderText( const TextInfo& ti, bool forceColour = false );
 	
 private:
 	std::string fonts[GAME_FONTS];

--- a/rwengine/src/engine/ScreenText.cpp
+++ b/rwengine/src/engine/ScreenText.cpp
@@ -29,45 +29,124 @@ void ScreenText::tick(float dt)
 ScreenTextEntry ScreenTextEntry::makeBig(const std::string& id, const std::string& str, int style, int durationMS)
 {
 	switch(style) {
+
+	// Color: Blue
+	// Font: Pricedown
+	// Style: Italic (lowercase only)
+	// Horizontally: Centered
+	// Vertically: Baseline at y = 252 (from top)
+	// Size: 25 Pixel high letters ('S', 'l')
 	case 1:
 		return {
 			str,
-			{320.f, 400.f},
+			{320.f, 252.f},
 			1,
 			50,
-			{ 3,  3,   0,   0},
-			{20, 20, 200},
+			{ 2,  0,   0,   0},
+			{58, 119, 133},
 			1,
 			durationMS,
 			0,
 			600,
 			id
 		};
+
+	// Color: Yellow/Gold
+	// Font: Pricedown
+	// Style: Italic (lowercase only)
+	// Horizontally: Right at x = 620 (from left)
+	// Vertically: Baseline at y = 380 (from top)
+	// Size: 22 Pixel high letters ('S', 'l')
 	case 2:
 		return {
 			str,
 			{620.f, 380.f},
 			1,
 			30,
-			{  3,   3, 0,   0},
-			{205, 162, 7},
+			{  2,   3, 0,   0},
+			{214, 171, 9},
 			2,
 			durationMS,
 			0,
 			600,
 			id
 		};
+
+	// Color: Light brown
+	// Font: Pricedown
+	// Style: Italic (lowercase only)
+	// Horizontally: Right at x = 620 (from left)
+	// Vertically: Baseline at y = 427 (from top)
+	// Size: 28 Pixel high letters ('S', 'l')
+	case 3:
+		return {
+			str,
+			{320.f, 400.f},
+			1,
+			50,
+			{ 5,  5,   0,   0},
+			{169, 123, 88}, /// @todo verify
+			1,
+			durationMS,
+			0,
+			600,
+			id
+		};
+
+	// Color: Blue
+	// Font: Arial
+	// Style: Italic
+	// Horizontally: Centered
+	// Vertically: Baseline at y = 176 (from top)
+	// Size: 20 Pixel high letters ('S', 'l')
+	case 4:
+	case 5:
+		return {
+			str,
+			{320.f, 176.f},
+			2,
+			50,
+			((style == 4) ? glm::u8vec4({ 2, 2, 0, 0}) : glm::u8vec4({ -2, -2, 0, 0 })),
+			{90, 115, 150}, /// @todo verify
+			1,
+			durationMS,
+			0,
+			600,
+			id
+		};
+
+	// Color: Brown
+	// Font: Arial
+	// Style: Italic
+	// Horizontally: Centered
+	// Vertically: Baseline at y = 240 (from top)
+	// Size: 16 Pixel high letters ('S', 'l')
+	case 6:
+		return {
+			str,
+			{320.f, 240.f},
+			2,
+			50,
+			{ 2, 2, 0, 0},
+			{152, 89, 39},
+			1,
+			durationMS,
+			0,
+			600,
+			id
+		};
+
 	default:
 		RW_ERROR("Unhandled text style");
 		break;
 	}
 
 	return {
-		"Error",
+		"Error, style " + std::to_string(style),
 		{320.f, 400.f},
-		1,
+		2,
 		50,
-		{20, 20,   0,   0},
+		{20, 20, 0, 0},
 		{20, 20, 200},
 		1,
 		durationMS,

--- a/rwengine/src/engine/ScreenText.cpp
+++ b/rwengine/src/engine/ScreenText.cpp
@@ -158,12 +158,18 @@ ScreenTextEntry ScreenTextEntry::makeBig(const std::string& id, const std::strin
 
 ScreenTextEntry ScreenTextEntry::makeHighPriority(const std::string& id, const std::string& str, int durationMS)
 {
+	// Color: ?
+	// Font: Arial
+	// Style: Italic
+	// Horizontally: Centered
+	// @todo verify: Vertically: Baseline at y = 431 (from top)
+	// @todo verify: Size: 15 Pixel high letters ('S', 'l')
 	return {
 		str,
 		{320.f, 420.f},
 		2,
 		18,
-		{0, 0,   0,   0},
+		{1, 0, 0, 0},
 		{255, 255, 255},
 		1,
 		durationMS,

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -211,7 +211,15 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti, bool forceColour
 		{
 			switch( text[i+1] )
 			{
-			case 'k': {
+			case 'g': // Green
+				text.erase(text.begin()+i, text.begin()+i+3);
+				colour = glm::vec3(glm::u8vec3(90, 157, 102)) * (1/255.f);
+				break;
+			case 'h': // White
+				text.erase(text.begin()+i, text.begin()+i+3);
+				colour = glm::vec3(1.f); /// @todo FIXME! Use proper colour!
+				break;
+			case 'k': { // Key
 				text.erase(text.begin()+i, text.begin()+i+3);
 				// Extract the key name from the /next/ markup
 				auto keyend = text.find('~', i+1);
@@ -219,14 +227,23 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti, bool forceColour
 				// Since we don't have a key map yet, just print out the name
 				text.erase(text.begin()+i, text.begin()+keyend);
 				text.insert(i, keyname);
-			} break;
-			case 'w':
-				text.erase(text.begin()+i, text.begin()+i+3);
-				colour = ti.baseColour;
 				break;
-			case 'h':
+			}
+			case 'l': // Black
 				text.erase(text.begin()+i, text.begin()+i+3);
-				colour = glm::vec3(1.f);
+				colour = glm::vec3(0.f); /// @todo FIXME! Use proper colour!
+				break;
+			case 'r': // Red
+				text.erase(text.begin()+i, text.begin()+i+3);
+				colour = glm::vec3(1.f, 0.0f, 0.0f); /// @todo FIXME! Use proper colour!
+				break;
+			case 'w': // Gray
+				text.erase(text.begin()+i, text.begin()+i+3);
+				colour = glm::vec3(0.5f); /// @todo FIXME! Use proper colour!
+				break;
+			case 'y': // Yellow
+				text.erase(text.begin()+i, text.begin()+i+3);
+				colour = glm::vec3(1.0f, 1.0f, 0.0f); /// @todo FIXME! Use proper colour!
 				break;
 			}
 			

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -177,7 +177,7 @@ void TextRenderer::setFontTexture(int index, const std::string& texture)
 	}
 }
 
-void TextRenderer::renderText(const TextRenderer::TextInfo& ti)
+void TextRenderer::renderText(const TextRenderer::TextInfo& ti, bool forceColour)
 {
 	renderer->getRenderer()->pushDebugGroup("Text");
 	renderer->getRenderer()->useProgram(textShader);
@@ -231,6 +231,10 @@ void TextRenderer::renderText(const TextRenderer::TextInfo& ti)
 			}
 			
 			c = text[i];
+		}
+
+		if (forceColour) {
+			colour = glm::vec3(ti.baseColour) * (1/255.f);
 		}
 		
 		int glyph = charToIndex(c);

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -237,13 +237,15 @@ void drawOnScreenText(GameWorld* world, GameRenderer* renderer)
 			// Check for the background type
 			if (t.colourBG.a == 0)
 			{
+				glm::vec2 shadowPosition((int8_t)t.colourBG.x, (int8_t)t.colourBG.y);
+
 				ti.baseColour = glm::vec3(0.f);
-				ti.screenPosition += glm::vec2(t.colourBG.x, t.colourBG.y);
+				ti.screenPosition += shadowPosition;
 				ti.backgroundColour = {0, 0, 0, 0};
 
-				renderer->text.renderText(ti);
+				renderer->text.renderText(ti, true);
 
-				ti.screenPosition -= glm::vec2(t.colourBG.x, t.colourBG.y);
+				ti.screenPosition -= shadowPosition;
 			}
 			else if(t.colourBG.a > 0)
 			{


### PR DESCRIPTION
I've used [this wiki page](http://www.gtamodding.com/wiki/00BA) to document (in the form of comments) each font style of the Big texts and the HighPriority messages.
The documentation (to my knowledge) should be complete, though I'm a manly man and I lack in giving colors a funny name so color names might not be precise.

After documenting I started an implementation.
Except for the `duration` I've tried to implement everything.
Note that the `y` position is set to the intended baseline position (where letters except for "q, y, p" etc. start from the bottom) but OpenRW has no way to respect this properly so texts might be off on the vertical axis.
I also didn't verify the font size in my implementation. and I assume that's also bad currently.
I wasn't sure around the wrap size either and wether any of the fonts might use some sort of vertical alignment.

For colors I've opened the screenshots (png) in gimp and tried to average the color of a couple of pixels for the italic Arial (or whatever it is). For the pricedown font I've tried to pick pixels which had the most intensity to guess the color.
I did not verify the exact font colors yet.
Also, the font colors are currently hardcoded (for both, font styles and color markup) inline. We should probably move them to a header at some point but for now this will work fine.

I did not have any luck finding uncompressed screenshots of the [markup text colors](http://www.gtamodding.com/wiki/GXT) (with the exception of green) so I've added very rough versions for those and marked them as @todo.

There also used to be a bug where the shadow was rendered like any other text. That also meant that it respected the markup and therefore became colored.
I've fixed this by adding an optional parameter. Ideally we should only generate the final text string once and duplicate the outcoming vertices (or do the shadows in a shader or something).
However, that's an issue for future authors of OpenRW.

---

TODO:
- [x] Cleanup
- [x] PR description
