### PR TITLE
Refactor TXD loader and support more formats

### DIFF
--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -30,12 +30,6 @@
 #include <core/Profiler.hpp>
 
 const size_t skydomeSegments = 8, skydomeRows = 10;
-constexpr uint32_t kMissingTextureBytes[] = {
-	0xFF0000FF, 0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF,
-	0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF, 0xFF0000FF,
-	0xFF0000FF, 0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF,
-	0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF, 0xFF0000FF,
-};
 
 struct WaterVertex {
 	static const AttributeList vertex_attributes() {
@@ -115,12 +109,6 @@ GameRenderer::GameRenderer(Logger* log, GameData* _data)
 		GameShaders::DefaultPostProcess::FragmentShader);
 
 	glGenVertexArrays( 1, &vao );
-
-	glGenTextures(1, &m_missingTexture);
-	glBindTexture(GL_TEXTURE_2D, m_missingTexture);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 4, 4, 0, GL_RGBA, GL_UNSIGNED_BYTE, kMissingTextureBytes);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
 	glGenFramebuffers(1, &framebufferName);
 	glBindFramebuffer(GL_FRAMEBUFFER, framebufferName);
@@ -337,8 +325,7 @@ void GameRenderer::renderWorld(GameWorld* world, const ViewCamera &camera, float
 
 	ObjectRenderer objectRenderer(_renderWorld,
 					  (cullOverride ? cullingCamera : _camera),
-					  _renderAlpha,
-					  getMissingTexture());
+					  _renderAlpha);
 
 	// World Objects
 	for (auto object : world->allObjects) {

--- a/rwengine/src/render/GameRenderer.hpp
+++ b/rwengine/src/render/GameRenderer.hpp
@@ -91,9 +91,6 @@ class GameRenderer
 	GLuint fbRenderBuffers[1];
 	Renderer::ShaderProgram* postProg;
 
-	/// Texture used to replace textures missing from the data
-	GLuint m_missingTexture;
-
 public:
 	
 	GameRenderer(Logger* log, GameData* data);
@@ -120,8 +117,6 @@ public:
 	GeometryBuffer cylinderGeometry;
 
 	GameData* getData() const { return data; }
-
-	GLuint getMissingTexture() const { return m_missingTexture; }
 
     /**
 	 * Renders the world using the parameters of the passed Camera.

--- a/rwengine/src/render/ObjectRenderer.cpp
+++ b/rwengine/src/render/ObjectRenderer.cpp
@@ -71,7 +71,9 @@ void ObjectRenderer::renderGeometry(Model* model,
 					if( ! tex )
 					{
 						//logger->warning("Renderer", "Missing texture: " + tC + " " + tA);
-						dp.textures = { m_errorTexture };
+            //FIXME: Make tA optional in debugLabel
+            auto errorTexture = getErrorTexture("name='" + tC + "';alpha='" + tA + "';missing");
+						dp.textures = { errorTexture->getName() };
 					}
 					mat.textures[0].texture = tex;
 				}

--- a/rwengine/src/render/ObjectRenderer.hpp
+++ b/rwengine/src/render/ObjectRenderer.hpp
@@ -23,12 +23,10 @@ class ObjectRenderer
 public:
 	ObjectRenderer(GameWorld* world,
 				   const ViewCamera& camera,
-				   float renderAlpha,
-				   GLuint errorTexture)
+				   float renderAlpha)
 		: m_world (world)
 		, m_camera(camera)
 		, m_renderAlpha(renderAlpha)
-		, m_errorTexture(errorTexture)
 	{ }
 
 	/**
@@ -42,7 +40,6 @@ private:
 	GameWorld* m_world;
 	const ViewCamera& m_camera;
 	float m_renderAlpha;
-	GLuint m_errorTexture;
 
 	void renderInstance(InstanceObject *instance, RenderList& outList);
 	void renderCharacter(CharacterObject *pedestrian, RenderList& outList);

--- a/rwlib/source/gl/TextureData.cpp
+++ b/rwlib/source/gl/TextureData.cpp
@@ -1,1 +1,32 @@
 #include <gl/TextureData.hpp>
+
+static constexpr uint32_t gErrorTextureData[] = {
+	0xFF0000FF, 0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF,
+	0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF, 0xFF0000FF,
+	0xFF0000FF, 0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF,
+	0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF, 0xFF0000FF,
+};
+
+TextureData::Handle getErrorTexture()
+{
+	static GLuint errTexName = 0;
+	static TextureData::Handle tex;
+	if(errTexName == 0)
+	{
+		glGenTextures(1, &errTexName);
+		glBindTexture(GL_TEXTURE_2D, errTexName);
+		glTexImage2D(
+			GL_TEXTURE_2D, 0, GL_RGBA,
+			4, 4, 0,
+			GL_RGBA, GL_UNSIGNED_BYTE, gErrorTextureData
+		);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+ 		tex = TextureData::create(errTexName, {4, 4}, false);
+  }
+
+  return tex;
+}

--- a/rwlib/source/gl/TextureData.cpp
+++ b/rwlib/source/gl/TextureData.cpp
@@ -7,7 +7,7 @@ static constexpr uint32_t gErrorTextureData[] = {
 	0xFFFF00FF, 0xFF0000FF, 0xFFFF00FF, 0xFF0000FF,
 };
 
-TextureData::Handle getErrorTexture()
+TextureData::Handle getErrorTexture(std::string debugLabel)
 {
 	static GLuint errTexName = 0;
 	static TextureData::Handle tex;
@@ -27,6 +27,8 @@ TextureData::Handle getErrorTexture()
 
  		tex = TextureData::create(errTexName, {4, 4}, false);
   }
+
+  glObjectLabel(GL_TEXTURE, errTexName, -1, (debugLabel != "" ? debugLabel.c_str() : NULL));
 
   return tex;
 }

--- a/rwlib/source/gl/TextureData.hpp
+++ b/rwlib/source/gl/TextureData.hpp
@@ -32,3 +32,5 @@ private:
 	glm::ivec2 size;
 	bool hasAlpha;
 };
+
+TextureData::Handle getErrorTexture();

--- a/rwlib/source/gl/TextureData.hpp
+++ b/rwlib/source/gl/TextureData.hpp
@@ -33,4 +33,4 @@ private:
 	bool hasAlpha;
 };
 
-TextureData::Handle getErrorTexture();
+TextureData::Handle getErrorTexture(std::string debugLabel = "");

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -207,7 +207,11 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, glWrapMode(texNative.wrapU));
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, glWrapMode(texNative.wrapV));
 
-  glObjectLabel(GL_TEXTURE, textureName, -1, debugLabel.c_str());
+	// @todo Maybe the order if these is bad
+	auto wrapU = (texNative.wrap >> 4) & 0xF;
+	auto wrapV = texNative.wrap & 0xF;
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, glWrapMode(wrapU));
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, glWrapMode(wrapV));
 
   glObjectLabel(GL_TEXTURE, textureName, -1, debugLabel.c_str());
 

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -57,6 +57,7 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 	bool isPal4 = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_PAL4); //FIXME!
 	bool isPal8 = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_PAL8) == RW::BSTextureNative::FORMAT_EXT_PAL8;
 
+  bool hasMipMaps = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_MIPMAP); //FIXME!
   bool generateMipMaps = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_MIPMAP); //FIXME!
 
 	// Export this value

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -175,12 +175,20 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
     return GL_REPEAT;
   };
 
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, glTexFilter(texNative.filterflags));
+	bool useMipMaps = false;
+  if (generateMipMaps) {
+	  glGenerateMipmap(GL_TEXTURE_2D);
+		useMipMaps = true;
+	} else if (hasMipMaps) {
+		// @todo Load mipmaps from file instead
+	  glGenerateMipmap(GL_TEXTURE_2D);
+		useMipMaps = true;
+	}
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, glTexFilter(texNative.filterflags, useMipMaps));
+
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, glWrapMode(texNative.wrapU));
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, glWrapMode(texNative.wrapV));
-
-	glGenerateMipmap(GL_TEXTURE_2D);
 
 	return TextureData::create( textureName, { texNative.width, texNative.height }, transparent );
 }

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -4,32 +4,6 @@
 #include <iostream>
 #include <algorithm>
 
-GLuint gErrorTextureData[] = { 0xFFFF00FF, 0xFF000000, 0xFF000000, 0xFFFF00FF };
-GLuint gDebugTextureData[] = {0xFF0000FF, 0xFF00FF00};
-GLuint gTextureRed[] = {0xFF0000FF};
-GLuint gTextureGreen[] = {0xFF00FF00};
-GLuint gTextureBlue[] = {0xFFFF0000};
-
-TextureData::Handle getErrorTexture()
-{
-	static GLuint errTexName = 0;
-	static TextureData::Handle tex;
-	if(errTexName == 0)
-	{
-		glGenTextures(1, &errTexName);
-		glBindTexture(GL_TEXTURE_2D, errTexName);
-		glTexImage2D(
-			GL_TEXTURE_2D, 0, GL_RGBA,
-			2, 2, 0,
-			GL_RGBA, GL_UNSIGNED_BYTE, gErrorTextureData
-		);
-		glGenerateMipmap(GL_TEXTURE_2D);
-
-		tex = TextureData::create(errTexName, {2, 2}, false);
-	}
-	return tex;
-}
-
 const size_t paletteSize = 1024;
 void processPalette(uint32_t* fullColor, RW::BinaryStreamSection& rootSection)
 {

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -1,8 +1,11 @@
 #include <loaders/LoaderTXD.hpp>
 #include <gl/TextureData.hpp>
 
-#include <iostream>
 #include <algorithm>
+#include <iostream>
+#include <sstream>
+
+#include <boost/format.hpp>
 
 const size_t paletteSize = 1024;
 void processPalette(uint32_t* fullColor, RW::BinaryStreamSection& rootSection)
@@ -20,13 +23,16 @@ void processPalette(uint32_t* fullColor, RW::BinaryStreamSection& rootSection)
 
 }
 
-TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStreamSection& rootSection)
+TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStreamSection& rootSection, std::string debugLabel = "")
 {
 	// TODO: Exception handling.
 	if(texNative.platform != 8) {
 		std::cerr << "Unsupported texture platform " << std::dec << texNative.platform << std::endl;
-		return getErrorTexture();
+    debugLabel += (boost::format("platform-not-supported:%d;") % texNative.platform).str();
+		return getErrorTexture(debugLabel);
 	}
+
+  debugLabel += (boost::format("rasterformat:0x%X;") % texNative.platform).str();
 
 	bool isPal4 = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_PAL4); //FIXME!
 	bool isPal8 = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_PAL8) == RW::BSTextureNative::FORMAT_EXT_PAL8;
@@ -45,7 +51,8 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 	if(isPal4)
 	{
 		std::cerr << "Unsuported palette mode" << std::endl;
-		return getErrorTexture();
+		debugLabel += "pal4-not-supported;";
+		return getErrorTexture(debugLabel);
 	} else if(isPal8)
 	{
 		std::vector<uint32_t> fullColor(texNative.width * texNative.height);
@@ -83,7 +90,8 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 			  break;
 		  default:
         assert(false); // This should never happen, only the formats above are known.
-        return getErrorTexture();
+        debugLabel += "bad-dxt;";
+        return getErrorTexture(debugLabel);
 		  }
 
       // Complain if the s3tc-extension is not available
@@ -132,7 +140,7 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 			    break;
 	    default:
           std::cerr << "Unsuported raster format " << std::dec << rasterformat << (isDxt ? " (Compressed)" : "") << std::endl;
-          return getErrorTexture();
+          return getErrorTexture(debugLabel);
 	    }
 		  glGenTextures(1, &textureName);
 		  glBindTexture(GL_TEXTURE_2D, textureName);
@@ -201,6 +209,8 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 
   glObjectLabel(GL_TEXTURE, textureName, -1, debugLabel.c_str());
 
+  glObjectLabel(GL_TEXTURE, textureName, -1, debugLabel.c_str());
+
 	return TextureData::create( textureName, { texNative.width, texNative.height }, transparent );
 }
 
@@ -217,13 +227,21 @@ bool TextureLoader::loadFromMemory(FileHandle file, TextureArchive &inTextures)
 		if (rootSection.header.id != RW::SID_TextureNative)
 			continue;
 
+    std::string debugLabel = "";
 		RW::BSTextureNative texNative = rootSection.readStructure<RW::BSTextureNative>();
-		std::string name = std::string(texNative.diffuseName);
-		std::string alpha = std::string(texNative.alphaName);
-		std::transform(name.begin(), name.end(), name.begin(), ::tolower );
-		std::transform(alpha.begin(), alpha.end(), alpha.begin(), ::tolower );
 
-		auto texture = createTexture(texNative, rootSection);
+		std::string name = std::string(texNative.diffuseName);
+    debugLabel += "name:'" + name + "';";
+		std::transform(name.begin(), name.end(), name.begin(), ::tolower );
+
+    // Get name for the optional alpha texture
+		std::string alpha = std::string(texNative.alphaName);
+    if (alpha != "") {
+        debugLabel += "alpha:'" + alpha + "';";
+		    std::transform(alpha.begin(), alpha.end(), alpha.begin(), ::tolower );
+    }
+
+		auto texture = createTexture(texNative, rootSection, debugLabel);
 
 		inTextures[{name, alpha}] = texture;
 

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -57,6 +57,8 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 	bool isPal4 = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_PAL4); //FIXME!
 	bool isPal8 = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_PAL8) == RW::BSTextureNative::FORMAT_EXT_PAL8;
 
+  bool generateMipMaps = (texNative.rasterformat & RW::BSTextureNative::FORMAT_EXT_MIPMAP); //FIXME!
+
 	// Export this value
 	bool transparent = !((texNative.rasterformat&RW::BSTextureNative::FORMAT_888) == RW::BSTextureNative::FORMAT_888);
 
@@ -221,6 +223,8 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
 
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, glWrapMode(texNative.wrapU));
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, glWrapMode(texNative.wrapV));
+
+  glObjectLabel(GL_TEXTURE, textureName, -1, debugLabel.c_str());
 
 	return TextureData::create( textureName, { texNative.width, texNative.height }, transparent );
 }

--- a/rwlib/source/loaders/LoaderTXD.cpp
+++ b/rwlib/source/loaders/LoaderTXD.cpp
@@ -135,48 +135,50 @@ TextureData::Handle createTexture(RW::BSTextureNative& texNative, RW::BinaryStre
     }
   }
 
-	GLenum texFilter = GL_LINEAR;
-	switch(texNative.filterflags & 0xFF) {
-	default:
-	case RW::BSTextureNative::FILTER_LINEAR:
-		texFilter = GL_LINEAR;
-		break;
-	case RW::BSTextureNative::FILTER_NEAREST:
-		texFilter = GL_NEAREST;
-		break;
-	}
+  auto glTexFilter = [](uint8_t filter, bool mipmap) -> GLenum {
+    switch(filter) {
+    case RW::BSTextureNative::FILTER_NEAREST:
+      return GL_NEAREST;
+    case RW::BSTextureNative::FILTER_LINEAR:
+      return GL_LINEAR;
+    case RW::BSTextureNative::FILTER_MIP_NEAREST:
+			// @todo Verify
+      return mipmap ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
+    case RW::BSTextureNative::FILTER_MIP_LINEAR:
+			// @todo Verify
+      return mipmap ? GL_NEAREST_MIPMAP_LINEAR : GL_NEAREST;
+    case RW::BSTextureNative::FILTER_LINEAR_MIP_NEAREST:
+      return mipmap ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR;
+    case RW::BSTextureNative::FILTER_LINEAR_MIP_LINEAR:
+      return mipmap ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR;
+    case RW::BSTextureNative::FILTER_NONE: // @todo Check what this is
+    default:
+      assert(false);
+      break;
+    }
+    return GL_LINEAR;
+  };
+
+  auto glWrapMode = [](uint8_t mode) -> GLenum {
+    switch(mode) {
+    case RW::BSTextureNative::WRAP_WRAP:
+      return GL_REPEAT;
+    case RW::BSTextureNative::WRAP_CLAMP:
+      return GL_CLAMP_TO_EDGE;
+    case RW::BSTextureNative::WRAP_MIRROR:
+      return GL_MIRRORED_REPEAT;
+    case RW::BSTextureNative::WRAP_NONE: // @todo Check what this is
+    default:
+      assert(false);
+      break;
+    }
+    return GL_REPEAT;
+  };
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, texFilter);
-
-	GLenum texwrap = GL_REPEAT;
-	switch(texNative.wrapU) {
-	default:
-	case RW::BSTextureNative::WRAP_WRAP:
-		texwrap = GL_REPEAT;
-		break;
-	case RW::BSTextureNative::WRAP_CLAMP:
-		texwrap = GL_CLAMP_TO_EDGE;
-		break;
-	case RW::BSTextureNative::WRAP_MIRROR:
-		texwrap = GL_MIRRORED_REPEAT;
-		break;
-	}
-	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, texwrap );
-
-	switch(texNative.wrapV) {
-	default:
-	case RW::BSTextureNative::WRAP_WRAP:
-		texwrap = GL_REPEAT;
-		break;
-	case RW::BSTextureNative::WRAP_CLAMP:
-		texwrap = GL_CLAMP_TO_EDGE;
-		break;
-	case RW::BSTextureNative::WRAP_MIRROR:
-		texwrap = GL_MIRRORED_REPEAT;
-		break;
-	}
-	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, texwrap );
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, glTexFilter(texNative.filterflags));
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, glWrapMode(texNative.wrapU));
+	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, glWrapMode(texNative.wrapV));
 
 	glGenerateMipmap(GL_TEXTURE_2D);
 

--- a/rwlib/source/loaders/RWBinaryStream.hpp
+++ b/rwlib/source/loaders/RWBinaryStream.hpp
@@ -247,6 +247,7 @@ namespace RW
 	
 	struct BSTextureNative
 	{
+    // @todo Use enum types for those defined below
 		uint32_t platform;
 		uint16_t filterflags;
 		uint8_t wrapV;

--- a/rwlib/source/loaders/RWBinaryStream.hpp
+++ b/rwlib/source/loaders/RWBinaryStream.hpp
@@ -249,9 +249,9 @@ namespace RW
 	{
     // @todo Use enum types for those defined below
 		uint32_t platform;
-		uint16_t filterflags;
-		uint8_t wrapV;
-		uint8_t wrapU;
+		uint8_t filterflags;
+		uint8_t wrap;
+    uint16_t _pad;
 		char diffuseName[32]; 
 		char alphaName[32];
 		uint32_t rasterformat;


### PR DESCRIPTION
---

TODO:
- [ ] PR description
- [x] Check for `EXT_texture_compression_s3tc` for TXDs
- Support all formats
  - [ ] FORMAT_DEFAULT         0x0000
  - [x] FORMAT_1555            0x0100 (1 bit alpha, RGB 5 bits each)
  - [x] FORMAT_565             0x0200 (5 bits red, 6 bits green, 5 bits blue)
  - [x] FORMAT_4444            0x0300 (RGBA 4 bits each)
  - [x] DXT: FORMAT_1555            0x0100 (1 bit alpha, RGB 5 bits each; DXT1 with alpha)
  - [x] DXT: FORMAT_565             0x0200 (5 bits red, 6 bits green, 5 bits blue; DXT1 without alpha)
  - [x] DXT: FORMAT_4444            0x0300 (RGBA 4 bits each; DXT3)
  - [ ] FORMAT_LUM8            0x0400 (gray scale, D3DFMT_L8)
  - [x] FORMAT_8888            0x0500 (RGBA 8 bits each)
  - [x] FORMAT_888             0x0600 (RGB 8 bits each, D3DFMT_X8R8G8B8)
  - [ ] FORMAT_555             0x0A00 (RGB 5 bits each - rare, use 565 instead, D3DFMT_X1R5G5B5)
- Support palette modes (do these work with all formats?)
  - [x] FORMAT_EXT_PAL8        0x2000 (2^8 = 256 palette colors)
  - [ ] FORMAT_EXT_PAL4        0x4000 (2^4 = 16 palette colors)
- Mipmaps
  - [ ] FORMAT_EXT_AUTO_MIPMAP 0x1000 (RW generates mipmaps, see special section below)
  - [ ] FORMAT_EXT_MIPMAP      0x8000 (mipmaps included)
- [x] Debug-label textures with their source name and TXD format
- [ ] Isolate GL debug stuff
- [ ] Cleanup
