### PR TITLE
Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
 	add_definitions(-DRW_FREEBSD)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	add_definitions(-DRW_WINDOWS)
-	set(BULLET_ROOT "$ENV{BULLET_ROOT}")
-	include_directories("$ENV{BULLET_ROOT}/src")
 else ()
 	message(FATAL_ERROR "Unknown platform \"${CMAKE_SYSTEM_NAME}\". please update CMakeLists.txt.")
 endif ()
@@ -95,6 +93,7 @@ find_package(SDL2 REQUIRED)
 include_directories(
 	${SDL2_INCLUDE_DIR}
 	${GLM_INCLUDE_DIRS}
+	${BULLET_INCLUDE_DIRS}
 )
 
 # External-internal dependencies

--- a/cmake/modules/FindSDL2.cmake
+++ b/cmake/modules/FindSDL2.cmake
@@ -1,4 +1,4 @@
-
+# Locate SDL2 library
 # This module defines
 # SDL2_LIBRARY, the name of the library to link against
 # SDL2_FOUND, if false, do not try to link to SDL2
@@ -6,13 +6,13 @@
 #
 # This module responds to the the flag:
 # SDL2_BUILDING_LIBRARY
-# If this is defined, then no SDL2main will be linked in because
+# If this is defined, then no SDL2_main will be linked in because
 # only applications need main().
 # Otherwise, it is assumed you are building an application and this
 # module will attempt to locate and set the the proper link flags
 # as part of the returned SDL2_LIBRARY variable.
 #
-# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# Don't forget to include SDL2main.h and SDL2main.m your project for the
 # OS X framework based version. (Other versions link to -lSDL2main which
 # this module will try to find on your behalf.) Also for OS X, this
 # module will automatically add the -framework Cocoa on your behalf.
@@ -37,7 +37,7 @@
 # and providing a more controlled/consistent search behavior.
 # Added new modifications to recognize OS X frameworks and
 # additional Unix paths (FreeBSD, etc).
-# Also corrected the header search path to follow "proper" SDL guidelines.
+# Also corrected the header search path to follow "proper" SDL2 guidelines.
 # Added a search for SDL2main which is needed by some platforms.
 # Added a search for threads which is needed by some platforms.
 # Added needed compile switches for MinGW.
@@ -48,183 +48,149 @@
 # CMAKE_INCLUDE_PATH to modify the search paths.
 #
 # Note that the header path has changed from SDL2/SDL.h to just SDL.h
-# This needed to change because "proper" SDL convention
+# This needed to change because "proper" SDL2 convention
 # is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
 # reasons because not all systems place things in SDL2/ (see FreeBSD).
+#
+# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
+# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
+# was not created for redistribution, and exists temporarily pending official
+# SDL2 CMake modules.
 
 #=============================================================================
 # Copyright 2003-2009 Kitware, Inc.
 #
-# Distributed under the OSI-approved BSD License (the "License").
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
 #
 # This software is distributed WITHOUT ANY WARRANTY; without even the
 # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 # See the License for more information.
 #=============================================================================
-# CMake - Cross Platform Makefile Generator
-# Copyright 2000-2016 Kitware, Inc.
-# Copyright 2000-2011 Insight Software Consortium
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 
-# * Redistributions of source code must retain the above copyright
-#   notice, this list of conditions and the following disclaimer.
-# 
-# * Redistributions in binary form must reproduce the above copyright
-#   notice, this list of conditions and the following disclaimer in the
-#   documentation and/or other materials provided with the distribution.
-# 
-# * Neither the names of Kitware, Inc., the Insight Software Consortium,
-#   nor the names of their contributors may be used to endorse or promote
-#   products derived from this software without specific prior written
-#   permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
-# ------------------------------------------------------------------------------
-# 
-# The above copyright and license notice applies to distributions of
-# CMake in source and binary form.  Some source files contain additional
-# notices of original copyright by their contributors; see each source
-# for details.  Third-party software packages supplied with CMake under
-# compatible licenses provide their own copyright notices documented in
-# corresponding subdirectories.
-# 
-# ------------------------------------------------------------------------------
-# 
-# CMake was initially developed by Kitware with the following sponsorship:
-# 
-#  * National Library of Medicine at the National Institutes of Health
-#    as part of the Insight Segmentation and Registration Toolkit (ITK).
-# 
-#  * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
-#    Visualization Initiative.
-# 
-#  * National Alliance for Medical Image Computing (NAMIC) is funded by the
-#    National Institutes of Health through the NIH Roadmap for Medical Research,
-#    Grant U54 EB005149.
-# 
-#  * Kitware, Inc.
-#
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
 
-message("<FindSDL2.cmake>")
 
-SET(SDL2_SEARCH_PATHS
-    ~/Library/Frameworks
-    /Library/Frameworks
-    /usr/local
-    /usr
-    /sw # Fink
-    /opt/local # DarwinPorts
-    /opt/csw # Blastwave
-    /opt
-    ${SDL2_PATH}
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+  HINTS
+  $ENV{SDL2DIR}
+  PATH_SUFFIXES include/SDL2 include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/include/SDL2
+  /usr/include/SDL2
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+)
+#MESSAGE("SDL2_INCLUDE_DIR is ${SDL2_INCLUDE_DIR}")
+
+FIND_LIBRARY(SDL2_LIBRARY_PATH
+  NAMES SDL2
+  HINTS
+  $ENV{SDL2DIR}
+  PATH_SUFFIXES lib64 lib
+  PATHS
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
 )
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(VC_LIB_PATH_SUFFIX lib/x64)
-else()
-    set(VC_LIB_PATH_SUFFIX lib/x86)
-endif()
+set(SDL2_LIBRARY_ONLY ${SDL2_LIBRARY_PATH} CACHE STRING "The SDL2 library, with no other libraries.")
+set(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_PATH})
 
-FIND_LIBRARY(SDL2_LIBRARY_TEMP
-    NAMES SDL2
-    HINTS
-    $ENV{SDL2DIR}
-    PATH_SUFFIXES lib64 lib ${VC_LIB_PATH_SUFFIX}
-    PATHS ${SDL2_SEARCH_PATHS}
-)
+#MESSAGE("SDL2_LIBRARY_TEMP is ${SDL2_LIBRARY_TEMP}")
 
-IF(SDL2_LIBRARY_TEMP)
-    FIND_PATH(SDL2_INCLUDE_DIR SDL.h
-        HINTS
-        $ENV{SDL2DIR}
-        PATH_SUFFIXES include/SDL2 include
-        PATHS ${SDL2_SEARCH_PATHS}
+IF(NOT SDL2_BUILDING_LIBRARY)
+  IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+    # Non-OS X framework versions expect you to also dynamically link to
+    # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+    # seem to provide SDL2main for compatibility even though they don't
+    # necessarily need it.
+    FIND_LIBRARY(SDL2MAIN_LIBRARY
+      NAMES SDL2main
+      HINTS
+      $ENV{SDL2DIR}
+      PATH_SUFFIXES lib64 lib
+      PATHS
+      /sw
+      /opt/local
+      /opt/csw
+      /opt
     )
+  ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
 
-    IF(NOT SDL2_BUILDING_LIBRARY)
-        IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
-            # Non-OS X framework versions expect you to also dynamically link to
-            # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
-            # seem to provide SDL2main for compatibility even though they don't
-            # necessarily need it.
-            FIND_LIBRARY(SDL2MAIN_LIBRARY
-                NAMES SDL2main
-                HINTS
-                $ENV{SDL2DIR}
-                PATH_SUFFIXES lib64 lib
-                PATHS ${SDL2_SEARCH_PATHS}
-            )
-        ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
-    ENDIF(NOT SDL2_BUILDING_LIBRARY)
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+  FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
 
-    # SDL2 may require threads on your system.
-    # The Apple build may not need an explicit flag because one of the
-    # frameworks may already provide it.
-    # But for non-OSX systems, I will use the CMake Threads package.
-    IF(NOT APPLE)
-        FIND_PACKAGE(Threads)
-    ENDIF(NOT APPLE)
+# MinGW needs an additional library, mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
+# (Actually on second look, I think it only needs one of the m* libraries.)
+IF(MINGW)
+  SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
 
-    # MinGW needs an additional library, mwindows
-    # It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -lmwindows
-    # (Actually on second look, I think it only needs one of the m* libraries.)
-    IF(MINGW)
-        SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
-    ENDIF(MINGW)
+SET(SDL2_FOUND "NO")
+IF(SDL2_LIBRARY_TEMP)
+  # For SDL2main
+  IF(NOT SDL2_BUILDING_LIBRARY)
+    IF(SDL2MAIN_LIBRARY)
+      SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+    ENDIF(SDL2MAIN_LIBRARY)
+  ENDIF(NOT SDL2_BUILDING_LIBRARY)
 
-    # For SDL2main
-    IF(NOT SDL2_BUILDING_LIBRARY)
-        IF(SDL2MAIN_LIBRARY)
-            SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
-        ENDIF(SDL2MAIN_LIBRARY)
-    ENDIF(NOT SDL2_BUILDING_LIBRARY)
+  # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+  # CMake doesn't display the -framework Cocoa string in the UI even
+  # though it actually is there if I modify a pre-used variable.
+  # I think it has something to do with the CACHE STRING.
+  # So I use a temporary variable until the end so I can set the
+  # "real" variable in one-shot.
+  IF(APPLE)
+    SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+  ENDIF(APPLE)
 
-    # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
-    # CMake doesn't display the -framework Cocoa string in the UI even
-    # though it actually is there if I modify a pre-used variable.
-    # I think it has something to do with the CACHE STRING.
-    # So I use a temporary variable until the end so I can set the
-    # "real" variable in one-shot.
-    IF(APPLE)
-        SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
-    ENDIF(APPLE)
+  # For threads, as mentioned Apple doesn't need this.
+  # In fact, there seems to be a problem if I used the Threads package
+  # and try using this line, so I'm just skipping it entirely for OS X.
+  IF(NOT APPLE)
+    SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+  ENDIF(NOT APPLE)
 
-    # For threads, as mentioned Apple doesn't need this.
-    # In fact, there seems to be a problem if I used the Threads package
-    # and try using this line, so I'm just skipping it entirely for OS X.
-    IF(NOT APPLE)
-        SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
-    ENDIF(NOT APPLE)
+  # For MinGW library
+  IF(MINGW)
+    SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+  ENDIF(MINGW)
+  
+  IF(WIN32)
+    SET(SDL2_LIBRARY_TEMP winmm imm32 version msimg32 ${SDL2_LIBRARY_TEMP})
+  ENDIF(WIN32)
 
-    # For MinGW library
-    IF(MINGW)
-        SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
-    ENDIF(MINGW)
+  # Set the final string here so the GUI reflects the final state.
+  SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+  # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+  SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
 
-    # Set the final string here so the GUI reflects the final state.
-    SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
-
-    # Unset the temp variable to INTERNAL so it is not seen in the CMake GUI
-    UNSET(SDL2_LIBRARY_TEMP)
+  SET(SDL2_FOUND "YES")
 ENDIF(SDL2_LIBRARY_TEMP)
-
-message("</FindSDL2.cmake>")
 
 INCLUDE(FindPackageHandleStandardArgs)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
+                                  REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)
+
+IF(SDL2_STATIC)
+  if (UNIX AND NOT APPLE)
+    EXECUTE_PROCESS(COMMAND sdl2-config --static-libs OUTPUT_VARIABLE SDL2_LINK_FLAGS)
+    STRING(REGEX REPLACE "(\r?\n)+$" "" SDL2_LINK_FLAGS "${SDL2_LINK_FLAGS}")
+    SET(SDL2_LIBRARY ${SDL2_LINK_FLAGS})
+  ENDIF()
+ENDIF(SDL2_STATIC)

--- a/rwengine/CMakeLists.txt
+++ b/rwengine/CMakeLists.txt
@@ -25,7 +25,6 @@ set(RWENGINE_SOURCES
 	src/audio/SoundManager.hpp
 	src/audio/alCheck.cpp
 	src/audio/alCheck.hpp
-	src/core/FileArchive.hpp
 	src/core/Logger.cpp
 	src/core/Logger.hpp
 	src/core/Profiler.cpp

--- a/rwengine/src/ai/CharacterController.cpp
+++ b/rwengine/src/ai/CharacterController.cpp
@@ -1,7 +1,7 @@
 #include <ai/CharacterController.hpp>
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
-#include <BulletDynamics/btBulletDynamicsCommon.h>
+#include <btBulletDynamicsCommon.h>
 
 #include <data/Model.hpp>
 #include <engine/Animator.hpp>

--- a/rwengine/src/dynamics/CollisionInstance.hpp
+++ b/rwengine/src/dynamics/CollisionInstance.hpp
@@ -2,7 +2,7 @@
 #ifndef _COLLISIONINSTANCE_HPP_
 #define _COLLISIONINSTANCE_HPP_
 
-#include <bullet/btBulletDynamicsCommon.h>
+#include <btBulletDynamicsCommon.h>
 #include <vector>
 #include <string>
 

--- a/rwengine/src/dynamics/RaycastCallbacks.hpp
+++ b/rwengine/src/dynamics/RaycastCallbacks.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <bullet/btBulletDynamicsCommon.h>
+#include <btBulletDynamicsCommon.h>
 
 /**
  * Implements raycast callback that ignores a specified btCollisionObject

--- a/rwengine/src/engine/GameData.cpp
+++ b/rwengine/src/engine/GameData.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <boost/algorithm/string/predicate.hpp>
 
 // Yet another hack function to fix these paths
 std::string fixPath(std::string path) {
@@ -159,17 +160,15 @@ bool GameData::loadObjects(const std::string& name)
 	return false;
 }
 
-#include <strings.h>
 uint16_t GameData::findModelObject(const std::string model)
 {
-	// Dear C++ Why do I have to resort to strcasecmp this isn't C.
 	auto defit = std::find_if(objectTypes.begin(), objectTypes.end(),
 							  [&](const decltype(objectTypes)::value_type& d)
 							  {
 								  if(d.second->class_type == ObjectInformation::_class("OBJS"))
 								  {
 									  auto dat = static_cast<ObjectData*>(d.second.get());
-									  return strcasecmp(dat->modelName.c_str(), model.c_str()) == 0;
+									  return boost::iequals(dat->modelName, model);
 								  }
 								  return false;
 							  });

--- a/rwengine/src/engine/GameWorld.cpp
+++ b/rwengine/src/engine/GameWorld.cpp
@@ -147,7 +147,7 @@ bool GameWorld::placeItems(const std::string& name)
 		for(auto& p: instancePool.objects) {
 			auto object = p.second;
 			InstanceObject* instance = static_cast<InstanceObject*>(object);
-			if( !instance->object->LOD ) {
+			if( !instance->object->LOD && instance->object->modelName.length() > 3) {
 				auto lodInstit = modelInstances.find("LOD" + instance->object->modelName.substr(3));
 				if( lodInstit != modelInstances.end() ) {
 					instance->LODinstance = lodInstit->second;

--- a/rwengine/src/loaders/LoaderCOL.cpp
+++ b/rwengine/src/loaders/LoaderCOL.cpp
@@ -1,4 +1,5 @@
 #include "loaders/LoaderCOL.hpp"
+#include <algorithm>
 #include <string>
 #include <fstream>
 

--- a/rwengine/src/loaders/LoaderCutsceneDAT.cpp
+++ b/rwengine/src/loaders/LoaderCutsceneDAT.cpp
@@ -1,5 +1,6 @@
 #include <loaders/LoaderCutsceneDAT.hpp>
 #include <sstream>
+#include <algorithm>
 
 void LoaderCutsceneDAT::load(CutsceneTracks &tracks, FileHandle file)
 {

--- a/rwengine/src/loaders/LoaderIDE.cpp
+++ b/rwengine/src/loaders/LoaderIDE.cpp
@@ -1,10 +1,12 @@
 #include <loaders/LoaderIDE.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <fstream>
-#include <string>
+#include <functional>
 #include <map>
 #include <sstream>
-#include <algorithm>
+#include <string>
 
 bool LoaderIDE::load(const std::string &filename)
 {

--- a/rwengine/src/loaders/LoaderIPL.cpp
+++ b/rwengine/src/loaders/LoaderIPL.cpp
@@ -1,9 +1,11 @@
 #include <loaders/LoaderIPL.hpp>
 
-#include <fstream>
-#include <string>
-#include <sstream>
 #include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <functional>
+#include <sstream>
+#include <string>
 
 enum SectionTypes
 {

--- a/rwengine/src/loaders/WeatherLoader.cpp
+++ b/rwengine/src/loaders/WeatherLoader.cpp
@@ -1,5 +1,6 @@
 #include <loaders/WeatherLoader.hpp>
 
+#include <cctype>
 #include <iostream>
 #include <sstream>
 #include <fstream>

--- a/rwengine/src/objects/CharacterObject.hpp
+++ b/rwengine/src/objects/CharacterObject.hpp
@@ -2,8 +2,8 @@
 #ifndef _CHARACTEROBJECT_HPP_
 #define _CHARACTEROBJECT_HPP_
 #include <objects/GameObject.hpp>
-#include <bullet/BulletDynamics/Character/btKinematicCharacterController.h>
-#include <bullet/btBulletCollisionCommon.h>
+#include <BulletDynamics/Character/btKinematicCharacterController.h>
+#include <btBulletCollisionCommon.h>
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <glm/glm.hpp>
 #include <array>

--- a/rwengine/src/objects/PickupObject.hpp
+++ b/rwengine/src/objects/PickupObject.hpp
@@ -2,7 +2,7 @@
 #ifndef _PICKUPOBJECT_HPP_
 #define _PICKUPOBJECT_HPP_
 #include <objects/GameObject.hpp>
-#include <bullet/btBulletCollisionCommon.h>
+#include <btBulletCollisionCommon.h>
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 #include <glm/glm.hpp>
 

--- a/rwengine/src/objects/ProjectileObject.hpp
+++ b/rwengine/src/objects/ProjectileObject.hpp
@@ -3,7 +3,7 @@
 #define _PROJECTILEOBJECT_HPP_
 #include <objects/GameObject.hpp>
 #include <data/WeaponData.hpp>
-#include <bullet/btBulletDynamicsCommon.h>
+#include <btBulletDynamicsCommon.h>
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 
 /**

--- a/rwengine/src/render/GameRenderer.cpp
+++ b/rwengine/src/render/GameRenderer.cpp
@@ -1,3 +1,6 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include <render/GameRenderer.hpp>
 #include <engine/GameWorld.hpp>
 #include <engine/Animator.hpp>

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -3,6 +3,7 @@
 #include <engine/GameWorld.hpp>
 
 #include <algorithm>
+#include <cctype>
 
 /// @todo This is very rough
 int charToIndex(char g)

--- a/rwengine/src/render/TextRenderer.cpp
+++ b/rwengine/src/render/TextRenderer.cpp
@@ -113,7 +113,7 @@ TextRenderer::TextInfo::TextInfo()
 }
 
 TextRenderer::TextRenderer(GameRenderer* renderer)
-: fonts({}), renderer(renderer)
+: renderer(renderer)
 {
 	textShader = renderer->getRenderer()->createShader(
 		TextVertexShader, TextFragmentShader );

--- a/rwengine/src/script/ScriptMachine.cpp
+++ b/rwengine/src/script/ScriptMachine.cpp
@@ -207,12 +207,12 @@ void ScriptMachine::executeThread(SCMThread &t, int msPassed)
 ScriptMachine::ScriptMachine(GameState* _state, SCMFile *file, SCMOpcodes *ops)
     : _file(file), _ops(ops), state(_state), interupt(false)
 {
-	auto globals = _file->getGlobalsSize();
-	globalData.resize(globals);
-	for(size_t i = 0; i < globals; ++i)
-	{
-		globalData[i] = 0;
-	}
+  // Copy globals
+	auto size = _file->getGlobalsSize();
+	globalData.resize(size);
+  auto offset = _file->getGlobalSection();
+	std::copy(_file->data()+offset, _file->data()+offset+size,
+	          globalData.begin());
 }
 
 ScriptMachine::~ScriptMachine()

--- a/rwengine/src/script/modules/GameModule.cpp
+++ b/rwengine/src/script/modules/GameModule.cpp
@@ -116,6 +116,9 @@ bool game_is_button_pressed(const ScriptArguments& args)
 
 void game_set_dead_or_arrested(const ScriptArguments& args)
 {
+	if (args.getWorld()->state->scriptOnMissionFlag == nullptr) {
+		return;
+	}
 	*args.getWorld()->state->scriptOnMissionFlag = args[0].integer;
 }
 

--- a/rwengine/src/script/modules/ObjectModule.cpp
+++ b/rwengine/src/script/modules/ObjectModule.cpp
@@ -271,19 +271,16 @@ bool game_character_near_point_on_foot_3D(const ScriptArguments& args)
 	return false;
 }
 
-bool game_player_near_point_on_foot_3D(const ScriptArguments& args)
+bool game_player_near_point_3D(const ScriptArguments& args)
 {
     auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
     glm::vec3 center(args[1].real, args[2].real, args[3].real);
     glm::vec3 size(args[4].real, args[5].real, args[6].real);
     bool drawCylinder = !!args[7].integer;
 
-    auto vehicle = character->getCurrentVehicle();
-    if( ! vehicle ) {
-        auto distance = center - character->getPosition();
-        distance /= size;
-        if( glm::length( distance ) < 1.f ) return true;
-    }
+    auto distance = center - character->getPosition();
+    distance /= size;
+    if( glm::length( distance ) < 1.f ) return true;
 
     if( drawCylinder )
     {
@@ -293,46 +290,53 @@ bool game_player_near_point_on_foot_3D(const ScriptArguments& args)
     return false;
 }
 
+bool game_player_near_point_on_foot_3D(const ScriptArguments& args)
+{
+    auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
+    auto vehicle = character->getCurrentVehicle();
+    if(vehicle) {
+        return false;
+    }
+    return game_player_near_point_3D(args);
+}
+
 bool game_player_near_point_in_vehicle_3D(const ScriptArguments& args)
 {
     auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
-    glm::vec3 center(args[1].real, args[2].real, args[3].real);
-    glm::vec3 size(args[4].real, args[5].real, args[6].real);
-    bool unkown	= !!args[7].integer;
-	RW_UNUSED(unkown);
-
     auto vehicle = character->getCurrentVehicle();
-    if( vehicle ) {
-        auto distance = center - character->getPosition();
-        distance /= size;
-        if( glm::length( distance ) < 1.f ) return true;
+    if(!vehicle) {
+        return false;
     }
+    return game_player_near_point_3D(args);
+}
 
-    return false;
+bool game_player_stopped_near_point_3d(const ScriptArguments& args)
+{
+    auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
+    if (!character->isStopped()) {
+          return false;
+    }
+    return game_player_near_point_3D(args);
 }
 
 bool game_player_stopped_near_point_on_foot_3d(const ScriptArguments& args)
 {
-	auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
-	glm::vec3 center(args[1].real, args[2].real, args[3].real);
-	glm::vec3 size(args[4].real, args[5].real, args[6].real);
-	bool drawCylinder = !!args[7].integer;
+    auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
+    auto vehicle = character->getCurrentVehicle();
+    if(vehicle) {
+        return false;
+    }
+    return game_player_stopped_near_point_3d(args);
+}
 
-	auto vehicle = character->getCurrentVehicle();
-	if( ! vehicle ) {
-		auto distance = center - character->getPosition();
-		distance /= size;
-		if( glm::length( distance ) < 1.f && character->isStopped() ) {
-			return true;
-		}
-	}
-
-	if( drawCylinder )
-	{
-		args.getWorld()->drawAreaIndicator(AreaIndicatorInfo::Cylinder, center, size);
-	}
-
-	return false;
+bool game_player_stopped_near_point_in_vehicle_3d(const ScriptArguments& args)
+{
+    auto character = static_cast<CharacterObject*>(args.getPlayerCharacter(0));
+    auto vehicle = character->getCurrentVehicle();
+    if(!vehicle) {
+        return false;
+    }
+    return game_player_stopped_near_point_3d(args);
 }
 
 bool game_is_player_in_vehicle_near_character(const ScriptArguments& args)
@@ -1397,10 +1401,12 @@ ObjectModule::ObjectModule()
 	
 	bindFunction(0x00EF, game_locate_character_stopped_2d<CharacterObject>, 6, "Locate Character Stopped 2D" );
 
-	bindUnimplemented( 0x00F5, game_locate_character_in_sphere, 8, "Locate Player In Sphere" );
-    bindFunction(0x00F6, game_player_near_point_on_foot_3D, 8, "Is Player near point on foot" );
-    bindFunction(0x00F7, game_player_near_point_in_vehicle_3D, 8, "Is Player near point in car" );
+	bindFunction(0x00F5, game_player_near_point_3D, 8, "Locate Player In Sphere" );
+	bindFunction(0x00F6, game_player_near_point_on_foot_3D, 8, "Is Player near point on foot" );
+	bindFunction(0x00F7, game_player_near_point_in_vehicle_3D, 8, "Is Player near point in car" );
+	bindFunction(0x00F8, game_player_stopped_near_point_3d, 8, "Detect player stopped area 3d" );
 	bindFunction(0x00F9, game_player_stopped_near_point_on_foot_3d, 8, "Detect player stopped on foot area 3d" );
+	bindFunction(0x00FA, game_player_stopped_near_point_in_vehicle_3d, 8, "Detect player stopped in car area 3d" );
 
 	bindFunction(0x00FD, game_is_player_in_vehicle_near_character, 6, "Is Player in Vehicle Near Character");
 

--- a/rwgame/CMakeLists.txt
+++ b/rwgame/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost REQUIRED)
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GitSHA1.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/GitSHA1.cpp" @ONLY)
 
 set(RWGAME_SOURCES

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -1,3 +1,6 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include "DrawUI.hpp"
 #include <render/GameRenderer.hpp>
 #include <ai/PlayerController.hpp>

--- a/rwgame/GameConfig.cpp
+++ b/rwgame/GameConfig.cpp
@@ -79,6 +79,11 @@ int GameConfig::handler(void* user,
 	{
 		self->m_gamePath = value;
 	}
+	else if (MATCH("game", "language"))
+	{
+		// @todo Don't allow path seperators and relative directories
+		self->m_gameLanguage = value;
+	}
 	else if (MATCH("input", "invert_y"))
 	{
 		self->m_inputInvertY = atoi(value) > 0;

--- a/rwgame/GameConfig.hpp
+++ b/rwgame/GameConfig.hpp
@@ -24,6 +24,7 @@ public:
 	bool isValid();
 
 	const std::string& getGameDataPath() const { return m_gamePath; }
+	const std::string& getGameLanguage() const { return m_gameLanguage; }
 	bool getInputInvertY() const { return m_inputInvertY; }
 
 private:
@@ -39,6 +40,9 @@ private:
 
 	/// Path to the game data
 	std::string m_gamePath;
+
+	/// Language for game
+	std::string m_gameLanguage = "american";
 
 	/// Invert the y axis for camera control.
 	bool m_inputInvertY;

--- a/rwgame/GameWindow.cpp
+++ b/rwgame/GameWindow.cpp
@@ -1,5 +1,3 @@
-#include <png.h>
-
 #include <core/Logger.hpp>
 #include "GameWindow.hpp"
 

--- a/rwgame/GameWindow.hpp
+++ b/rwgame/GameWindow.hpp
@@ -2,7 +2,7 @@
 #define GAMEWINDOW_HPP
 
 #include <string>
-#include <SDL2/SDL.h>
+#include "SDL.h"
 #include <glm/vec2.hpp>
 
 #include <render/GameRenderer.hpp>

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -25,6 +25,8 @@
 #include <objects/CharacterObject.hpp>
 #include <objects/VehicleObject.hpp>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include "GitSHA1.h"
 
 // Use first 8 chars of git hash as the build string
@@ -53,15 +55,15 @@ RWGame::RWGame(int argc, char* argv[])
 
 	for( int i = 1; i < argc; ++i )
 	{
-		if( strcasecmp( "-w", argv[i] ) == 0 && i+1 < argc )
+		if( boost::iequals( "-w", argv[i] ) && i+1 < argc )
 		{
 			w = std::atoi(argv[i+1]);
 		}
-		if( strcasecmp( "-h", argv[i] ) == 0 && i+1 < argc )
+		if( boost::iequals( "-h", argv[i] ) && i+1 < argc )
 		{
 			h = std::atoi(argv[i+1]);
 		}
-		if( strcasecmp( "-f", argv[i] ) == 0 )
+		if( boost::iequals( "-f", argv[i] ))
 		{
 			fullscreen = true;
 		}

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -127,7 +127,7 @@ RWGame::RWGame(int argc, char* argv[])
 	data->loadDynamicObjects(config.getGameDataPath() + "/data/object.dat");
 
 	/// @TODO language choices.
-	data->loadGXT("english.gxt");
+	data->loadGXT("american.gxt");
 	
 	getRenderer()->water.setWaterTable(data->waterHeights, 48, data->realWater, 128*128);
 	

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -90,7 +90,6 @@ RWGame::RWGame(int argc, char* argv[])
 
 	window = new GameWindow();
 	window->create(kWindowTitle + " [" + kBuildStr + "]", w, h, fullscreen);
-	window->hideCursor();
 
 	work = new WorkContext();
 

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -424,7 +424,7 @@ void RWGame::tick(float dt)
 		}
 		
 		// Clean up old VisualFX
-		for( ssize_t i = 0; i < static_cast<ssize_t>(world->effects.size()); ++i )
+		for( int i = 0; i < static_cast<int>(world->effects.size()); ++i )
 		{
 			VisualFX* effect = world->effects[i];
 			if( effect->getType() == VisualFX::Particle )

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -126,8 +126,7 @@ RWGame::RWGame(int argc, char* argv[])
 
 	data->loadDynamicObjects(config.getGameDataPath() + "/data/object.dat");
 
-	/// @TODO language choices.
-	data->loadGXT("american.gxt");
+	data->loadGXT(config.getGameLanguage() + ".gxt");
 	
 	getRenderer()->water.setWaterTable(data->waterHeights, 48, data->realWater, 128*128);
 	

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -12,7 +12,7 @@
 #include "GameConfig.hpp"
 #include "GameWindow.hpp"
 
-#include <SDL2/SDL.h>
+#include "SDL.h"
 
 class PlayerController;
 

--- a/rwgame/State.hpp
+++ b/rwgame/State.hpp
@@ -5,7 +5,8 @@
 #include <render/ViewCamera.hpp>
 #include "MenuSystem.hpp"
 #include <glm/gtc/quaternion.hpp>
-#include <SDL2/SDL.h>
+#include "SDL.h"
+#include "SDL_events.h"
 #include "GameWindow.hpp"
 
 class RWGame;

--- a/rwgame/states/BenchmarkState.hpp
+++ b/rwgame/states/BenchmarkState.hpp
@@ -1,7 +1,6 @@
 #ifndef _RWGAME_BENCHMARKSTATE_HPP_
 #define _RWGAME_BENCHMARKSTATE_HPP_
 
-#include <SDL2/SDL_events.h>
 #include "State.hpp"
 
 class BenchmarkState : public State

--- a/rwgame/states/DebugState.hpp
+++ b/rwgame/states/DebugState.hpp
@@ -1,7 +1,6 @@
 #ifndef DEBUGSTATE_HPP
 #define DEBUGSTATE_HPP
 
-#include <SDL2/SDL_events.h>
 #include "State.hpp"
 
 class DebugState : public State

--- a/rwgame/states/IngameState.hpp
+++ b/rwgame/states/IngameState.hpp
@@ -1,7 +1,6 @@
 #ifndef INGAMESTATE_HPP
 #define INGAMESTATE_HPP
 
-#include <SDL2/SDL_events.h>
 #include "State.hpp"
 
 class PlayerController;

--- a/rwgame/states/LoadingState.cpp
+++ b/rwgame/states/LoadingState.cpp
@@ -16,7 +16,6 @@ void LoadingState::enter()
 	}
 
 	game->newGame();
-	getWindow().hideCursor();
 }
 
 void LoadingState::exit()

--- a/rwgame/states/LoadingState.hpp
+++ b/rwgame/states/LoadingState.hpp
@@ -1,7 +1,6 @@
 #ifndef LOADINGSTATE_HPP
 #define LOADINGSTATE_HPP
 
-#include <SDL2/SDL_events.h>
 #include "State.hpp"
 
 class LoadingState : public State

--- a/rwgame/states/MenuState.hpp
+++ b/rwgame/states/MenuState.hpp
@@ -1,7 +1,6 @@
 #ifndef MENUSTATE_HPP
 #define MENUSTATE_HPP
 
-#include <SDL2/SDL_events.h>
 #include "State.hpp"
 
 class MenuState : public State

--- a/rwgame/states/PauseState.hpp
+++ b/rwgame/states/PauseState.hpp
@@ -1,7 +1,6 @@
 #ifndef PAUSESTATE_HPP
 #define PAUSESTATE_HPP
 
-#include <SDL2/SDL_events.h>
 #include "State.hpp"
 
 class PauseState : public State

--- a/rwlib/source/loaders/LoaderIMG.cpp
+++ b/rwlib/source/loaders/LoaderIMG.cpp
@@ -1,6 +1,6 @@
 #include <loaders/LoaderIMG.hpp>
 
-#include <cstring>
+#include <boost/algorithm/string/predicate.hpp>
 
 LoaderIMG::LoaderIMG()
 : m_version(GTAIIIVC)
@@ -50,7 +50,7 @@ bool LoaderIMG::findAssetInfo(const std::string& assetname, LoaderIMGFile& out)
 {
 	for(size_t i = 0; i < m_assets.size(); ++i)
 	{
-		if(strcasecmp(m_assets[i].name, assetname.c_str()) == 0)
+		if(boost::iequals(m_assets[i].name, assetname))
 		{
 			out = m_assets[i];
 			return true;

--- a/rwlib/source/loaders/LoaderSDT.cpp
+++ b/rwlib/source/loaders/LoaderSDT.cpp
@@ -1,6 +1,7 @@
 #include <loaders/LoaderSDT.hpp>
 
 #include <cstring>
+#include <string>
 
 LoaderSDT::LoaderSDT()
 : m_version(GTAIIIVC)

--- a/rwlib/source/loaders/RWBinaryStream.hpp
+++ b/rwlib/source/loaders/RWBinaryStream.hpp
@@ -353,11 +353,6 @@ namespace RW
 		{
 			return *reinterpret_cast<T*>(data+offset+sizeof(BSSectionHeader)+internalOffset);
 		}
-
-		template<class T*> T* readSubStructure(size_t internalOffset)
-		{
-			return reinterpret_cast<T*>(data+offset+sizeof(BSSectionHeader)+internalOffset);
-		}
 		
 		template<class T> T readRaw(size_t internalOffset)
 		{


### PR DESCRIPTION
This is not a pure cleanup (= some commits change behaviour) as I had to fix some smaller issues and annoyances.
The reason for all changes is higher compatibility with compilers and environments, increase code-readability and preventing crashes or UB.

(Don't be scared away; most of the ~250 lines in this commit are from a FindSDL2.cmake replacement. I recommend review per commit. Thanks!)
- Use FindSDL2.cmake from OpenMW
  Seems to work better than that from Citra. I can't remember the specifics at the moment though.
- Use bullet include path found by CMake module
  We used to craft our own path here and had a windows specific hack
- Fix SDL2 and Bullet #include paths
  Uses what's been suggested in the CMake modules
  (bullet include dir is a mess with duplicated include files accross subdirs etc.)
- Removes empty file (0 bytes) rwengine/core/FileArchive.hpp
  We should probably grep for binaries and empty files on travis? (Seperate issue)
- Include-What-You-Use
  Includes the std headers if we use some of their functions (breaks MSVC otherwise)
- Replace non-std C++ code with alternatives
  This commit still needs some work, please discuss below! (TODO)
- Switch default english.gxt to american.gxt
  There is no point in using english.gxt as the later games use american.gxt which is essentially the same.
- Extend the previous commit by allowing language selection in openrw.ini
  Needs extension of the wiki to include:
  
  ```
  [game]
  language=american
  ```
- Avoid error in substr if short modelname in LOD selection
  LOD selection does a substr(3) to skip the first characters 4, meaning it would crash if the string was shorter than 4 chars. Might appear in mods.
- Avoid crash if `scriptOnMissionFlag` is not linked by script
  This occurs in `game_set_dead_or_arrested` which probably shouldn't depend on that flag?
  We should probably fix this properly later. However, for now, this hack will be fine.
  Only happens with mods, not the original game.
- Replace strcasecmp with boost::iequals which is more portable
- Don't grab mouse cursor before going ingame
  Mostly to make development easier (the cursor would be released during the main menu again anyway). We probably should hide it though. We need a better API for that (Seperate issue).
- Simplify logic of player_near_point script functions 0xF5 - 0xFA and introduce missing versions of that
  The old code was overly complex - these opcodes are mostly variations of 00F5
- Script: Initialize globals from SCMFile
  Because.. why not? This is unverified though. We should check if this actually happens with the original game and if the code is correct or off-by-one or something (Seperate issue).

Please review for completeness, style consistency and **check if the new cmake/include setup works for your system**.

---

TODO:
- [x] PR description
- [x] Split misc commit from appveyor
- [x] Remove rwengine/src/core/FileArchive.hpp
- [x] From VC: Script: 022 (Float Greather than Global Int)
- [x] From VC: Switch default english.gxt to american.gxt
- [x] From VC: Avoid substr error in LOD selection with short strings
- [x] From VC: Don't grab mouse cursor before going ingame
- [x] From VC: Refactor player_near_point script functions 0xF5 - 0xFA
- [x] Move  @JayFoxRox  Script: 022 (Float Greather than Global Int)            0178e14
- [x] Use language from config file instead
- [x] Cleanup
