### PR TITLE
Cheat handler + Money display

### DIFF
--- a/rwengine/src/engine/GameState.hpp
+++ b/rwengine/src/engine/GameState.hpp
@@ -69,17 +69,17 @@ struct BasicState
 	BasicState ();
 };
 
-/** Block 15 player info */
+/** Block 16 player info */
 struct PlayerInfo
 {
-	uint16_t money;
+	uint32_t money;
 	uint8_t unknown1;
-	uint16_t unknown2;
-	uint8_t unknown3;
+	uint32_t unknown2;
+	uint16_t unknown3;
 	float unknown4;
-	uint16_t displayedMoney;
-	uint16_t hiddenPackagesCollected;
-	uint16_t hiddenPackageCount;
+	uint32_t displayedMoney;
+	uint32_t hiddenPackagesCollected;
+	uint32_t hiddenPackageCount;
 	uint8_t neverTired;
 	uint8_t fastReload;
 	uint8_t thaneOfLibertyCity;
@@ -92,26 +92,26 @@ struct PlayerInfo
 /** Block 17 */
 struct GameStats
 {
-	uint16_t playerKills;
-	uint16_t otherKills;
-	uint16_t carsExploded;
-	uint16_t shotsHit;
-	uint16_t pedTypesKilled[23];
-	uint16_t helicoptersDestroyed;
-	uint16_t playerProgress;
-	uint16_t explosiveKgsUsed;
-	uint16_t bulletsFired;
-	uint16_t bulletsHit;
-	uint16_t carsCrushed;
-	uint16_t headshots;
-	uint16_t timesBusted;
-	uint16_t timesHospital;
-	uint16_t daysPassed;
-	uint16_t mmRainfall;
-	uint16_t insaneJumpMaxDistance;
-	uint16_t insaneJumpMaxHeight;
-	uint16_t insaneJumpMaxFlips;
-	uint16_t insangeJumpMaxRotation;
+	uint32_t playerKills;
+	uint32_t otherKills;
+	uint32_t carsExploded;
+	uint32_t shotsHit;
+	uint32_t pedTypesKilled[23];
+	uint32_t helicoptersDestroyed;
+	uint32_t playerProgress;
+	uint32_t explosiveKgsUsed;
+	uint32_t bulletsFired;
+	uint32_t bulletsHit;
+	uint32_t carsCrushed;
+	uint32_t headshots;
+	uint32_t timesBusted;
+	uint32_t timesHospital;
+	uint32_t daysPassed;
+	uint32_t mmRainfall;
+	uint32_t insaneJumpMaxDistance;
+	uint32_t insaneJumpMaxHeight;
+	uint32_t insaneJumpMaxFlips;
+	uint32_t insangeJumpMaxRotation;
 	/*
 	 * 0 none completed
 	 * 1 insane stunt
@@ -123,36 +123,36 @@ struct GameStats
 	 * 7 quadruple
 	 * 8 perfect quadruple
 	 */
-	uint16_t bestStunt;
-	uint16_t uniqueStuntsFound;
-	uint16_t uniqueStuntsTotal;
-	uint16_t missionAttempts;
-	uint16_t missionsPassed;
-	uint16_t passengersDroppedOff;
-	uint16_t taxiRevenue;
-	uint16_t portlandPassed;
-	uint16_t stauntonPassed;
-	uint16_t shoresidePassed;
-	uint16_t bestTurismoTime;
+	uint32_t bestStunt;
+	uint32_t uniqueStuntsFound;
+	uint32_t uniqueStuntsTotal;
+	uint32_t missionAttempts;
+	uint32_t missionsPassed;
+	uint32_t passengersDroppedOff;
+	uint32_t taxiRevenue;
+	uint32_t portlandPassed;
+	uint32_t stauntonPassed;
+	uint32_t shoresidePassed;
+	uint32_t bestTurismoTime;
 	float distanceWalked;
 	float distanceDriven;
-	uint16_t patriotPlaygroundTime;
-	uint16_t aRideInTheParkTime;
-	uint16_t grippedTime;
-	uint16_t multistoryMayhemTime;
-	uint16_t peopleSaved;
-	uint16_t criminalsKilled;
-	uint16_t highestParamedicLevel;
-	uint16_t firesExtinguished;
-	uint16_t longestDodoFlight;
-	uint16_t bombDefusalTime;
-	uint16_t rampagesPassed;
-	uint16_t totalRampages;
-	uint16_t totalMissions;
-	uint16_t fastestTime[16]; // not used
-	uint16_t highestScore[16];
-	uint16_t peopleKilledSinceCheckpoint; // ?
-	uint16_t peopleKilledSinceLastBustedOrWasted;
+	uint32_t patriotPlaygroundTime;
+	uint32_t aRideInTheParkTime;
+	uint32_t grippedTime;
+	uint32_t multistoryMayhemTime;
+	uint32_t peopleSaved;
+	uint32_t criminalsKilled;
+	uint32_t highestParamedicLevel;
+	uint32_t firesExtinguished;
+	uint32_t longestDodoFlight;
+	uint32_t bombDefusalTime;
+	uint32_t rampagesPassed;
+	uint32_t totalRampages;
+	uint32_t totalMissions;
+	uint32_t fastestTime[16]; // not used
+	uint32_t highestScore[16];
+	uint32_t peopleKilledSinceCheckpoint; // ?
+	uint32_t peopleKilledSinceLastBustedOrWasted;
 	char lastMissionGXT[8];
 
 	GameStats ();

--- a/rwgame/DrawUI.cpp
+++ b/rwgame/DrawUI.cpp
@@ -86,7 +86,12 @@ void drawPlayerInfo(PlayerController* player, GameWorld* world, GameRenderer* re
 
 	infoTextY += ui_textHeight;
 
-	ti.text = GameSymbols::Money + GameStringUtil::fromString(std::to_string(world->state->playerInfo.money));
+	{
+		std::stringstream ss;
+		ss << std::setw(8) << std::setfill('0') << world->state->playerInfo.displayedMoney;
+
+		ti.text = GameSymbols::Money + GameStringUtil::fromString(ss.str());
+	}
 	ti.baseColour = ui_shadowColour;
 	ti.screenPosition = glm::vec2(infoTextX + 1.f, infoTextY+1.f);
 	render->text.renderText(ti);

--- a/rwgame/RWGame.cpp
+++ b/rwgame/RWGame.cpp
@@ -24,6 +24,7 @@
 #include <objects/VehicleObject.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <functional>
 
 #include "GitSHA1.h"
 
@@ -269,6 +270,176 @@ PlayerController *RWGame::getPlayer()
 		return static_cast<PlayerController*>(controller);
 	}
 	return nullptr;
+}
+
+// Modifiers for GTA3 we try to recreate
+#define RW_GAME_VERSION 1100
+#define RW_GAME_GTA3_GERMAN 0
+#define RW_GAME_GTA3_ANNIVERSARY 0
+
+void RWGame::handleCheatInput(char symbol) {
+	cheatInputWindow = cheatInputWindow.substr(1) + symbol;
+
+	// Helper to check for cheats
+	auto checkForCheat = [this](std::string cheat, std::function<void()> action) {
+		RW_CHECK(cheatInputWindow.length() >= cheat.length(), "Cheat too long");
+		size_t offset = cheatInputWindow.length() - cheat.length();
+		if (cheat == cheatInputWindow.substr(offset)) {
+			log.info("Game", "Cheat triggered: '" + cheat + "'");
+			if (action) {
+				action();
+			}
+		}
+	};
+
+	// Player related cheats
+	{
+		auto player = static_cast<CharacterObject*>(world->pedestrianPool.find(state->playerObject));
+
+#ifdef RW_GAME_GTA3_GERMAN // Germans got their own cheat
+		std::string health_cheat = "GESUNDHEIT";
+#else
+		std::string health_cheat = "HEALTH";
+#endif
+		checkForCheat(health_cheat, [&]{
+			player->getCurrentState().health = 100.f;
+			// @todo ShowHelpMessage("CHEAT3"); // III / VC: Inputting health cheat.
+		});
+
+#if RW_GAME_VERSION >= 1100 // Changed cheat name in version 1.1
+		std::string armor_cheat = "TORTOISE";
+#else
+		std::string armor_cheat = "TURTOISE";
+#endif
+		checkForCheat(armor_cheat, [&]{
+			player->getCurrentState().armour = 100.f;
+			// @todo ShowHelpMessage("CHEAT4"); // III / VC: Inputting armor cheat.
+		});
+
+		checkForCheat("GUNSGUNSGUNS", [&]{
+			// @todo give player weapons
+			// @todo ShowHelpMessage("CHEAT2"); // III / VC: Inputting weapon cheats.
+		});
+
+		checkForCheat("IFIWEREARICHMAN", [&]{
+			world->state->playerInfo.money += 250000;
+			// @todo ShowHelpMessage("CHEAT6"); // III: Inputting money cheat.
+		});
+
+		checkForCheat("MOREPOLICEPLEASE", [&]{
+			// @todo raise to next wanted level
+			// @todo ShowHelpMessage("CHEAT5"); // III / VC: Inputting wanted level cheats.
+		});
+
+		checkForCheat("NOPOLICEPLEASE", [&]{
+			// @todo lower to next lower wanted level
+			// @todo ShowHelpMessage("CHEAT5"); // III / VC: Inputting wanted level cheats.
+		});
+	}
+
+	// Misc cheats.
+	{
+		checkForCheat("BANGBANGBANG", [&]{
+			// @todo Explode nearby vehicles
+			// @todo What radius?
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("GIVEUSATANK", [&]{
+			// The iPod / Android version of the game (10th year anniversary) spawns random (?) vehicles instead of always rhino
+#ifdef RW_GAME_GTA3_ANNIVERSARY
+			uint16_t vehicleModel = 110; // @todo Which cars are spawned?!
+#else
+			uint16_t vehicleModel = 122;
+#endif
+			// @todo Spawn rhino
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("CORNERSLIKEMAD", [&]{
+			// @todo Weird car handling
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("ANICESETOFWHEELS", [&]{
+			// @todo Hide car bodies
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("CHITTYCHITTYBB", [&]{
+			// @todo Cars can fly
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("NASTYLIMBCHEAT", [&]{
+			// @todo Makes it possible to shoot limbs off, iirc?
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("ILIKEDRESSINGUP", [&]{
+			// @todo Which skins will be chosen?
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+	}
+
+	// Pedestrian cheats
+	{
+		checkForCheat("WEAPONSFORALL", [&]{
+			// @todo Give all pedestrians weapons.. this is also saved in the savegame?!
+			// @todo Which weapons do they get?
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("NOBODYLIKESME", [&]{
+			// @todo Set all pedestrians hostile towards player.. this is also saved in the savegame?!
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("ITSALLGOINGMAAAD", [&]{
+			// @todo Set all pedestrians to fighting each other.. this is also saved in the savegame?!
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		// Game speed cheats
+
+		checkForCheat("TIMEFLIESWHENYOU", [&]{
+			// @todo Set fast gamespeed
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+
+		checkForCheat("BOOOOORING", [&]{
+			// @todo Set slow gamespeed
+			// @todo ShowHelpMessage("CHEAT1"); // III / VC: Inputting most cheats.
+		});
+	}
+
+	// Weather cheats
+	{
+		checkForCheat("ILIKESCOTLAND", [&]{
+			// @todo Set weather to cloudy
+			// @todo ShowHelpMessage("CHEAT7"); // III / VC: Inputting weather cheats.
+		});
+
+		checkForCheat("SKINCANCERFORME", [&]{
+			// @todo Set sunny / normal weather
+			// @todo ShowHelpMessage("CHEAT7"); // III / VC: Inputting weather cheats.
+		});
+
+		checkForCheat("MADWEATHER", [&]{
+			// @todo Set bad weather
+			// @todo ShowHelpMessage("CHEAT7"); // III / VC: Inputting weather cheats.
+		});
+
+		checkForCheat("ILOVESCOTLAND", [&]{
+			// @todo Set weather to rainy
+			// @todo ShowHelpMessage("CHEAT7"); // III / VC: Inputting weather cheats.
+		});
+
+		checkForCheat("PEASOUP", [&]{
+			// @todo Set weather to foggy
+			// @todo ShowHelpMessage("CHEAT7"); // III / VC: Inputting weather cheats.
+		});
+	}
 }
 
 int RWGame::run()
@@ -796,5 +967,11 @@ void RWGame::globalKeyEvent(const SDL_Event& event)
 		showDebugPhysics = ! showDebugPhysics;
 		break;
 	default: break;
+	}
+
+	std::string keyName = SDL_GetKeyName(event.key.keysym.sym);
+	if (keyName.length() == 1) {
+		char symbol = keyName[0];
+		handleCheatInput(symbol);
 	}
 }

--- a/rwgame/RWGame.hpp
+++ b/rwgame/RWGame.hpp
@@ -39,6 +39,8 @@ class RWGame
 	bool showDebugPhysics = false;
 	int lastDraws; /// Number of draws issued for the last frame.
 
+	std::string cheatInputWindow = std::string(32, ' ');
+
 	float accum = 0.f;
 	float timescale = 1.f;
 public:
@@ -135,6 +137,8 @@ private:
 	void renderDebugStats(float time, Renderer::ProfileInfo& worldRenderTime);
 	void renderDebugPaths(float time);
 	void renderProfile();
+
+	void handleCheatInput(char symbol);
 
 	void globalKeyEvent(const SDL_Event& event);
 };

--- a/rwgame/states/IngameState.hpp
+++ b/rwgame/states/IngameState.hpp
@@ -32,6 +32,8 @@ class IngameState : public State
 	bool m_invertedY;
 	/// Free look in vehicles.
 	bool m_vehicleFreeLook;
+
+	float moneyTimer; // Timer used to updated displayed money value
 public:
     /**
      * @brief IngameState


### PR DESCRIPTION
This implements a cheat handler.
Only a couple of cheats are actually implemented.
There will have to be some decision how we will differentiate different official R\* versions of GTA3 as cheats were changed in different regions and updates. I've added some defines near the cheat handler as a temporary workaround.

This also fixes some issue with the game state which broke the "IFIWEREARICHMAN" cheat (money used to be `uint16_t` in OpenRW, and so many other values which are listed as dword on gtamodding).

As I was messing with the money values anyway I decided to improve the money display.
It's now zero-padded to 8 digits. The value also increases slowly now.
The behaviour for the [money counting was reverse engineered and documented here](https://docs.google.com/spreadsheets/d/1VwUk-HeDuJ_yC7p9vIhhoCzII7TPcZOvNGGOj1TjfIs/edit#gid=0). As you can see, OpenRW counts slightly faster than the original. I guess this is related to frameskips and being bound to framerate on the actual game. As OpenRW is running with dynamic timestep I introduced a timer instead and retrieve the 30Hz from that.

---

This causes crashes if cheats are typed before going ingame. Note that the actual game accepts cheats during the pause menu so we can't check in ingamestate (easily). I'm not sure but the original game might even crash when typing cheats on the main menu? There is probably an easy fix for this, but I don't know how to check wether we are ingame. The obvious solution for now is to not type cheats in the menus. I consider solving this crash beyond the scope.
(I'm pretty sure the original game also crashed if player related cheats were entered but there wasn't a player character; so I didn't add a check for that either)

---

TODO:
- [x] Cleanup
- [ ] Prevent cheats before going ingame?
